### PR TITLE
Add error widget on unexpected errors

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -32,7 +32,11 @@ import 'background_service/service.dart' as background_service;
 
 
 
-main() async {
+void main() async {
+  ErrorWidget.builder = (FlutterErrorDetails details) {
+    return errorWidget(details);
+  };
+
   WidgetsFlutterBinding.ensureInitialized();
 
   // Pass all uncaught "fatal" errors from the framework to Crashlytics
@@ -83,6 +87,50 @@ main() async {
   runApp(App(
     savedThemeMode: savedThemeMode,
   ));
+}
+
+Widget errorWidget(FlutterErrorDetails details) {
+  return Container(
+    color: Colors.red.withOpacity(0.1),
+    child: Padding(
+      padding: const EdgeInsets.only(left: 20.0, right: 20.0, top: 32.0, bottom: 32.0),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          const Icon(
+            Icons.warning,
+            size: 60,
+          ),
+          const Padding(
+            padding: EdgeInsets.all(35),
+            child: Text(
+                "Ups, es ist ein Fehler aufgetreten!",
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.bold,
+                )
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 35),
+            child: Text("Problem: ${details.exception.toString()}",
+              textAlign: TextAlign.center,
+            ),
+          ),
+          const Text(
+            "Solche Fehler werden normalerweise automatisch an den Entwickler gesendet.",
+            textAlign: TextAlign.center,
+            style: TextStyle(
+                fontSize: 9,
+                fontWeight: FontWeight.w400
+            ),
+          )
+        ],
+      ),
+    ),
+  );
 }
 
 class App extends StatelessWidget {

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -2,8 +2,11 @@ import 'dart:async';
 import 'dart:ui';
 import 'dart:io';
 
+import 'package:stack_trace/stack_trace.dart';
+
 import 'firebase_options.dart';
 
+import 'package:flutter/services.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -117,6 +120,32 @@ Widget errorWidget(FlutterErrorDetails details) {
             padding: const EdgeInsets.only(bottom: 35),
             child: Text("Problem: ${details.exception.toString()}",
               textAlign: TextAlign.center,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 35),
+            child: FilledButton(
+                onPressed: () async {
+                  await Clipboard.setData(ClipboardData(text: Trace.from(details.stack!).terse.toString()));
+                },
+                style: ButtonStyle(
+                  overlayColor: MaterialStateProperty.resolveWith((states) {
+                    return Colors.redAccent;
+                  }),
+                  foregroundColor: MaterialStateProperty.resolveWith((states) {
+                    return Colors.white;
+                  }),
+                  backgroundColor: MaterialStateProperty.resolveWith((states) {
+                    // If the button is pressed, return green, otherwise blue
+                    if (states.contains(MaterialState.pressed)) {
+                      return Colors.redAccent;
+                    }
+                    return Colors.red;
+                  }),
+                ),
+                child: const Text(
+                    "Fehlerdetails kopieren",
+                )
             ),
           ),
           const Text(

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -726,7 +726,7 @@ packages:
     source: hosted
     version: "1.10.0"
   stack_trace:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: stack_trace
       sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -60,6 +60,7 @@ dependencies:
   internet_connection_checker: ^1.0.0+1
   firebase_core: ^2.24.2
   firebase_crashlytics: ^3.4.8
+  stack_trace: ^1.11.1
 
 
 flutter_launcher_icons:


### PR DESCRIPTION
Zeigt ein Error Widget bei Fehlern, die (hauptsächlich) nicht durch den Parser oder Fetcher ausgelöst werden. Somit gibt es auch keinen grauen Screen mehr.

[Screencast from 2023-12-22 18-39-50.webm](https://github.com/alessioC42/lanis-mobile/assets/73837560/83867c06-d4a1-4480-819e-1cf79c4b0fb3)

![Screenshot from 2023-12-22 18-05-27](https://github.com/alessioC42/lanis-mobile/assets/73837560/84246856-5d6d-47ef-a729-4859f827cf27)

![Screenshot from 2023-12-22 18-04-47](https://github.com/alessioC42/lanis-mobile/assets/73837560/abcb0a19-1878-484d-97a9-53ca84b0fa95)
