### PR TITLE
Groß-/Kleinschreibung in der Erkennung von Modulen nicht beachten.

### DIFF
--- a/app/lib/client/client.dart
+++ b/app/lib/client/client.dart
@@ -511,6 +511,7 @@ class SPHclient {
   }
 
   final List<String> _onlySupportedByStudents = [
+    // only write lower case
     "mein unterricht",
   ];
 

--- a/app/lib/client/client.dart
+++ b/app/lib/client/client.dart
@@ -511,14 +511,13 @@ class SPHclient {
   }
 
   final List<String> _onlySupportedByStudents = [
-    "mein Unterricht",
-    "Mein Unterricht"
+    "mein unterricht",
   ];
 
   bool doesSupportFeature(String featureName) {
     for (var app in supportedApps) {
       if (app["Name"] == featureName) {
-        if ((_onlySupportedByStudents.contains(featureName))) {
+        if ((_onlySupportedByStudents.contains(featureName.toLowerCase()))) {
           return isStudentAccount();
         } else {
           return true;

--- a/app/lib/view/settings/subsettings/supported_features.dart
+++ b/app/lib/view/settings/subsettings/supported_features.dart
@@ -11,12 +11,12 @@ class SupportedFeaturesOverviewScreen extends StatefulWidget {
 
 
 final List<String> supportedApps = [
-  "Nachrichten - Beta-Version",
-  "Vertretungsplan",
-  "Mein Unterricht",
-  "mein Unterricht", //apparently some schools write this in lower case. Lanis is dumb
-  "Kalender",
-  "Logout",
+  // write in lower case only
+  "nachrichten - beta-version",
+  "vertretungsplan",
+  "mein unterricht",
+  "kalender",
+  "logout",
 ];
 
 
@@ -41,7 +41,7 @@ class _SupportedFeaturesOverviewScreenState extends State<SupportedFeaturesOverv
           leading: const Icon(Icons.settings_applications),
           iconColor: HexColor.fromHex(value["Farbe"]),
           title: Text(value["Name"]),
-          subtitle: Text(supportedApps.contains(value["Name"]) ? "Unterstützt": "nicht Unterstützt"),
+          subtitle: Text(supportedApps.contains(value["Name"].toString().toLowerCase()) ? "Unterstützt": "nicht Unterstützt"),
         ));
       }
 


### PR DESCRIPTION
In client und supported_features ist eine Liste von Modulen enthalten, die case-sensitive auf matches überprüft wird.
Dieser PR ändert sämtliche solchen Listen in vollständige Kleinschreibung und überprüft auch nur dagegen. So können Dopplungen mit unterschiedlichen Cases entfernt werden und ähnlichen Fehlern vorgebeugt werden.