### PR TITLE
Modul-Bezeichnungen als Enum implementieren

### DIFF
--- a/app/lib/client/client.dart
+++ b/app/lib/client/client.dart
@@ -16,6 +16,7 @@ import 'package:sph_plan/client/cryptor.dart';
 import 'package:sph_plan/client/fetcher.dart';
 import 'package:sph_plan/themes.dart';
 
+import '../shared/apps.dart';
 import '../shared/shared_functions.dart';
 
 class SPHclient {
@@ -52,31 +53,31 @@ class SPHclient {
 
   void prepareFetchers() {
     if (client.loadMode == "full") {
-      if (client.doesSupportFeature("Vertretungsplan") && substitutionsFetcher == null) {
+      if (client.doesSupportFeature(SPHAppEnum.vertretungsplan.str) && substitutionsFetcher == null) {
         substitutionsFetcher = SubstitutionsFetcher(const Duration(minutes: 15));
       }
-      if (client.doesSupportFeature("Mein Unterricht") && meinUnterrichtFetcher == null) {
+      if (client.doesSupportFeature(SPHAppEnum.meinUnterricht.str) && meinUnterrichtFetcher == null) {
         meinUnterrichtFetcher = MeinUnterrichtFetcher(const Duration(minutes: 15));
       }
-      if (client.doesSupportFeature("Nachrichten - Beta-Version")) {
+      if (client.doesSupportFeature(SPHAppEnum.nachrichtenBeta.str)) {
         visibleConversationsFetcher ??= VisibleConversationsFetcher(const Duration(minutes: 15));
         invisibleConversationsFetcher ??= InvisibleConversationsFetcher(const Duration(minutes: 15));
       }
-      if (client.doesSupportFeature("Kalender") && calendarFetcher == null) {
+      if (client.doesSupportFeature(SPHAppEnum.kalender.str) && calendarFetcher == null) {
         calendarFetcher = CalendarFetcher(null);
       }
     } else {
-      if (client.doesSupportFeature("Vertretungsplan") && substitutionsFetcher == null) {
+      if (client.doesSupportFeature(SPHAppEnum.vertretungsplan.str) && substitutionsFetcher == null) {
         substitutionsFetcher = SubstitutionsFetcher(null);
       }
-      if (client.doesSupportFeature("Mein Unterricht") && meinUnterrichtFetcher == null) {
+      if (client.doesSupportFeature(SPHAppEnum.meinUnterricht.str) && meinUnterrichtFetcher == null) {
         meinUnterrichtFetcher = MeinUnterrichtFetcher(null);
       }
-      if (client.doesSupportFeature("Nachrichten - Beta-Version")) {
+      if (client.doesSupportFeature(SPHAppEnum.nachrichtenBeta.str)) {
         visibleConversationsFetcher ??= VisibleConversationsFetcher(null);
         invisibleConversationsFetcher ??= InvisibleConversationsFetcher(null);
       }
-      if (client.doesSupportFeature("Kalender") && calendarFetcher == null) {
+      if (client.doesSupportFeature(SPHAppEnum.kalender.str) && calendarFetcher == null) {
         calendarFetcher = CalendarFetcher(null);
       }
     }
@@ -331,7 +332,7 @@ class SPHclient {
   }
 
   Future<dynamic> getCalendar(String startDate, String endDate) async {
-    if (!client.doesSupportFeature("Kalender")) {
+    if (!client.doesSupportFeature(SPHAppEnum.kalender.str)) {
       return -8;
     }
 
@@ -448,7 +449,7 @@ class SPHclient {
 
   Future<dynamic> getFullVplan({skipCheck= false}) async {
     if (!skipCheck) {
-      if (!client.doesSupportFeature("Vertretungsplan")) {
+      if (!client.doesSupportFeature(SPHAppEnum.vertretungsplan.str)) {
         return -8;
       }
     }
@@ -517,7 +518,7 @@ class SPHclient {
 
   bool doesSupportFeature(String featureName) {
     for (var app in supportedApps) {
-      if (app["Name"] == featureName) {
+      if (app["Name"].toString().toLowerCase() == featureName.toLowerCase()) {
         if ((_onlySupportedByStudents.contains(featureName.toLowerCase()))) {
           return isStudentAccount();
         } else {
@@ -586,7 +587,7 @@ class SPHclient {
   }
 
   Future<dynamic> getMeinUnterrichtOverview() async {
-    if (!client.doesSupportFeature("Mein Unterricht")) {
+    if (!client.doesSupportFeature(SPHAppEnum.meinUnterricht.str)) {
       return -8;
     }
     
@@ -873,7 +874,7 @@ class SPHclient {
   }
 
   Future<dynamic> getConversationsOverview(bool invisible) async {
-    if (!client.doesSupportFeature("Nachrichten - Beta-Version")) {
+    if (!client.doesSupportFeature(SPHAppEnum.nachrichtenBeta.str)) {
       return -8;
     }
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:dynamic_color/dynamic_color.dart';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:sph_plan/shared/apps.dart';
 import 'package:sph_plan/shared/whats_new.dart';
 import 'package:sph_plan/themes.dart';
 import 'package:stack_trace/stack_trace.dart';
@@ -252,11 +253,11 @@ class _HomePageState extends State<HomePage> {
   bool isLoading = true;
 
   Feature getDefaultFeature() {
-    if (client.doesSupportFeature("Vertretungsplan")) {
+    if (client.doesSupportFeature(SPHAppEnum.vertretungsplan.str)) {
       return Feature.substitutions;
-    } else if (client.doesSupportFeature("Kalender")) {
+    } else if (client.doesSupportFeature(SPHAppEnum.kalender.str)) {
       return Feature.calendar;
-    } else if (client.doesSupportFeature("Mein Unterricht")) {
+    } else if (client.doesSupportFeature(SPHAppEnum.meinUnterricht.str)) {
       return Feature.lessons;
     } else {
       return Feature.conversations;
@@ -348,7 +349,7 @@ class _HomePageState extends State<HomePage> {
       schoolName = client.schoolName;
 
       if (client.loadMode == "fast") {
-        if (client.doesSupportFeature("Vertretungsplan")) {
+        if (client.doesSupportFeature(SPHAppEnum.vertretungsplan.str)) {
           await fetchFeature([[Status.substitution, Status.errorSubstitution, client.substitutionsFetcher]]);
         }
 
@@ -363,21 +364,21 @@ class _HomePageState extends State<HomePage> {
 
       final features = [];
 
-      if (client.doesSupportFeature("Vertretungsplan")) {
+      if (client.doesSupportFeature(SPHAppEnum.vertretungsplan.str)) {
         features.add([
           Status.substitution,
           Status.errorSubstitution,
           client.substitutionsFetcher
         ]);
       }
-      if (client.doesSupportFeature("Mein Unterricht")) {
+      if (client.doesSupportFeature(SPHAppEnum.meinUnterricht.str)) {
         features.add([
           Status.meinUnterricht,
           Status.errorMeinUnterricht,
           client.meinUnterrichtFetcher
         ]);
       }
-      if (client.doesSupportFeature("Nachrichten - Beta-Version")) {
+      if (client.doesSupportFeature(SPHAppEnum.nachrichtenBeta.str)) {
         features.add([
           Status.conversations,
           Status.errorConversations,
@@ -389,7 +390,7 @@ class _HomePageState extends State<HomePage> {
           client.invisibleConversationsFetcher
         ]);
       }
-      if (client.doesSupportFeature("Kalender")) {
+      if (client.doesSupportFeature(SPHAppEnum.kalender.str)) {
         features.add([
           Status.calendar,
           Status.errorCalendar,
@@ -501,10 +502,10 @@ class _HomePageState extends State<HomePage> {
 
     int helpIndex = 0;
     for (var supported in [
-      client.doesSupportFeature("Vertretungsplan"),
-      client.doesSupportFeature("Kalender"),
-      client.doesSupportFeature("Nachrichten - Beta-Version"),
-      client.doesSupportFeature("Mein Unterricht")
+      client.doesSupportFeature(SPHAppEnum.vertretungsplan.str),
+      client.doesSupportFeature(SPHAppEnum.kalender.str),
+      client.doesSupportFeature(SPHAppEnum.nachrichtenBeta.str),
+      client.doesSupportFeature(SPHAppEnum.meinUnterricht.str)
     ]) {
       if (supported) {
         bottomNavbarNavigationTranslation.add(helpIndex);
@@ -566,25 +567,25 @@ class _HomePageState extends State<HomePage> {
                    onDestinationSelected: (index) => openFeature(Feature
                        .values[bottomNavbarNavigationTranslation.indexOf(index)]),
                    destinations: [
-                     if (client.doesSupportFeature("Vertretungsplan"))
+                     if (client.doesSupportFeature(SPHAppEnum.vertretungsplan.str))
                        const NavigationDestination(
                          icon: Icon(Icons.group),
                          selectedIcon: Icon(Icons.group_outlined),
                          label: 'Vertretungen',
                        ),
-                     if (client.doesSupportFeature("Kalender"))
+                     if (client.doesSupportFeature(SPHAppEnum.kalender.str))
                        const NavigationDestination(
                          icon: Icon(Icons.calendar_today),
                          selectedIcon: Icon(Icons.calendar_today_outlined),
                          label: 'Kalender',
                        ),
-                     if (client.doesSupportFeature("Nachrichten - Beta-Version"))
+                     if (client.doesSupportFeature(SPHAppEnum.nachrichtenBeta.str))
                        const NavigationDestination(
                          icon: Icon(Icons.forum),
                          selectedIcon: Icon(Icons.forum_outlined),
                          label: 'Nachrichten',
                        ),
-                     if (client.doesSupportFeature("Mein Unterricht"))
+                     if (client.doesSupportFeature(SPHAppEnum.meinUnterricht.str))
                        const NavigationDestination(
                          icon: Icon(Icons.school),
                          selectedIcon: Icon(Icons.school_outlined),
@@ -645,26 +646,26 @@ class _HomePageState extends State<HomePage> {
                       ),
                     ),
                     NavigationDrawerDestination(
-                      enabled: client.doesSupportFeature("Vertretungsplan"),
+                      enabled: client.doesSupportFeature(SPHAppEnum.vertretungsplan.str),
                       icon: const Icon(Icons.group),
                       selectedIcon: const Icon(Icons.group_outlined),
                       label: const Text('Vertretungsplan'),
                     ),
                     NavigationDrawerDestination(
-                      enabled: client.doesSupportFeature("Kalender"),
+                      enabled: client.doesSupportFeature(SPHAppEnum.kalender.str),
                       icon: const Icon(Icons.calendar_today),
                       selectedIcon: const Icon(Icons.calendar_today_outlined),
                       label: const Text('Kalender'),
                     ),
                     NavigationDrawerDestination(
                       enabled:
-                          client.doesSupportFeature("Nachrichten - Beta-Version"),
+                          client.doesSupportFeature(SPHAppEnum.nachrichtenBeta.str),
                       icon: const Icon(Icons.forum),
                       selectedIcon: const Icon(Icons.forum_outlined),
                       label: const Text('Nachrichten'),
                     ),
                     NavigationDrawerDestination(
-                      enabled: client.doesSupportFeature("Mein Unterricht"),
+                      enabled: client.doesSupportFeature(SPHAppEnum.meinUnterricht.str),
                       icon: const Icon(Icons.school),
                       selectedIcon: const Icon(Icons.school_outlined),
                       label: const Text('Mein Unterricht'),
@@ -820,7 +821,7 @@ class _HomePageState extends State<HomePage> {
                                   padding: const EdgeInsets.only(top: 16),
                                   child: Row(
                                     children: [
-                                      getIcon(status.data, Status.substitution, Status.errorSubstitution, "Vertretungsplan"),
+                                      getIcon(status.data, Status.substitution, Status.errorSubstitution, SPHAppEnum.vertretungsplan.str),
                                       Padding(
                                         padding: const EdgeInsets.only(left: 8),
                                         child: Text(
@@ -838,7 +839,7 @@ class _HomePageState extends State<HomePage> {
                                     padding: const EdgeInsets.only(top: 16),
                                     child: Row(
                                       children: [
-                                        getIcon(status.data, Status.meinUnterricht, Status.errorMeinUnterricht, "Mein Unterricht"),
+                                        getIcon(status.data, Status.meinUnterricht, Status.errorMeinUnterricht, SPHAppEnum.meinUnterricht.str),
                                         Padding(
                                           padding: const EdgeInsets.only(left: 8),
                                           child: Text(
@@ -855,7 +856,7 @@ class _HomePageState extends State<HomePage> {
                                     padding: const EdgeInsets.only(top: 16),
                                     child: Row(
                                       children: [
-                                        getIcon(status.data, Status.conversations, Status.errorConversations, "Nachrichten - Beta-Version"),
+                                        getIcon(status.data, Status.conversations, Status.errorConversations, SPHAppEnum.nachrichtenBeta.str),
                                         Padding(
                                           padding:
                                               const EdgeInsets.only(left: 8),
@@ -873,7 +874,7 @@ class _HomePageState extends State<HomePage> {
                                     padding: const EdgeInsets.only(top: 16),
                                     child: Row(
                                       children: [
-                                        getIcon(status.data, Status.calendar, Status.errorCalendar, "Kalender"),
+                                        getIcon(status.data, Status.calendar, Status.errorCalendar, SPHAppEnum.kalender.str),
                                         Padding(
                                           padding:
                                               const EdgeInsets.only(left: 8),

--- a/app/lib/shared/apps.dart
+++ b/app/lib/shared/apps.dart
@@ -1,0 +1,21 @@
+enum SPHAppEnum {
+  nachrichten,
+  nachrichtenBeta,
+  vertretungsplan,
+  meinUnterricht,
+  kalender,
+  logout
+}
+
+extension SPHApp on SPHAppEnum {
+  String get str {
+    return switch (this) {
+      SPHAppEnum.nachrichten => "nachrichten",
+      SPHAppEnum.nachrichtenBeta => "nachrichten - beta-version",
+      SPHAppEnum.vertretungsplan => "vertretungsplan",
+      SPHAppEnum.meinUnterricht => "mein unterricht",
+      SPHAppEnum.kalender => "kalender",
+      SPHAppEnum.logout => "logout"
+    };
+  }
+}

--- a/app/lib/view/bug_report/send_bugreport.dart
+++ b/app/lib/view/bug_report/send_bugreport.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import '../../client/client.dart';
+import '../../shared/apps.dart';
 
 class BugReportScreen extends StatefulWidget {
   final String? generatedMessage;
@@ -197,7 +198,7 @@ Future<dynamic> generateBugReport() async {
   //mein_unterricht
   late dynamic meinUnterricht;
   late List<dynamic> meinUnterrichtKurse = [];
-  if (client.doesSupportFeature("Kalender")) {
+  if (client.doesSupportFeature(SPHAppEnum.kalender.str)) {
     meinUnterricht = await client.getMeinUnterrichtOverview();
     meinUnterricht["kursmappen"]?.forEach((kurs) async {
       meinUnterrichtKurse.add(
@@ -212,7 +213,7 @@ Future<dynamic> generateBugReport() async {
   late dynamic visibleMessages;
   late dynamic invisibleMessages;
   late dynamic firstSingleMessage;
-  if (client.doesSupportFeature("Nachrichten - Beta-Version")) {
+  if (client.doesSupportFeature(SPHAppEnum.nachrichtenBeta.str)) {
     visibleMessages = await client.getConversationsOverview(false);
 
     for (var element in visibleMessages) {
@@ -240,13 +241,13 @@ Future<dynamic> generateBugReport() async {
       "userdata": await client.fetchUserData()
     },
     "applets": {
-      "vertretungsplan": client.doesSupportFeature("Vertretungsplan") ? await client.getFullVplan() ?? [] : [],
-      "kalender": client.doesSupportFeature("Kalender") ? await client.getCalendar(formatter.format(sixMonthsAgo), formatter.format(oneYearLater)) ?? [] : [],
+      "vertretungsplan": client.doesSupportFeature(SPHAppEnum.vertretungsplan.str) ? await client.getFullVplan() ?? [] : [],
+      "kalender": client.doesSupportFeature(SPHAppEnum.kalender.str) ? await client.getCalendar(formatter.format(sixMonthsAgo), formatter.format(oneYearLater)) ?? [] : [],
       "mein_unterricht": {
         "übersicht": meinUnterricht,
         "kurse": meinUnterrichtKurse
       },
-      "nachrichten": client.doesSupportFeature("Nachrichten - Beta-Version") ? {
+      "nachrichten": client.doesSupportFeature(SPHAppEnum.nachrichtenBeta.str) ? {
         "eingeblendete": visibleMessages,
         "ausgeblendete": invisibleMessages,
         "erste_detaillierte_nachricht": firstSingleMessage

--- a/app/lib/view/login/setup_screen_page_view_models.dart
+++ b/app/lib/view/login/setup_screen_page_view_models.dart
@@ -7,6 +7,7 @@ import 'package:sph_plan/view/settings/subsettings/theme_changer.dart';
 import 'package:sph_plan/view/vertretungsplan/substitutionWidget.dart';
 
 import '../../client/client.dart';
+import '../../shared/apps.dart';
 import '../vertretungsplan/filtersettings.dart';
 
 final _klassenStufeController = TextEditingController();
@@ -19,7 +20,7 @@ List<PageViewModel> setupScreenPageViewModels = [
       title: "Lehreraccount",
       body: "Du hast offenbar einen nicht-Schüleraccount. Du kannst die App trotzdem verwenden, aber es kann sein, dass einige Features nicht funktionieren."
     ),
-    if (client.doesSupportFeature("Vertretungsplan")) ...[
+    if (client.doesSupportFeature(SPHAppEnum.vertretungsplan.str)) ...[
     PageViewModel(
         image: SvgPicture.asset("assets/undraw/undraw_filter_re_sa16.svg", height: 175.0),
         title: "Vertretungen filtern",

--- a/app/lib/view/settings/settings.dart
+++ b/app/lib/view/settings/settings.dart
@@ -6,6 +6,7 @@ import 'package:sph_plan/view/settings/subsettings/supported_features.dart';
 import 'package:sph_plan/view/settings/subsettings/theme_changer.dart';
 import 'package:sph_plan/view/settings/subsettings/userdata.dart';
 
+import '../../shared/apps.dart';
 import '../login/screen.dart';
 import '../../client/client.dart';
 
@@ -61,7 +62,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               );
             },
           ),
-          if (client.doesSupportFeature("Vertretungsplan")) ...[
+          if (client.doesSupportFeature(SPHAppEnum.vertretungsplan.str)) ...[
             ListTile(
               leading: const Icon(Icons.notifications),
               title: const Text('Benachrichtigungen'),

--- a/app/lib/view/settings/subsettings/supported_features.dart
+++ b/app/lib/view/settings/subsettings/supported_features.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:sph_plan/client/client.dart';
 
+import '../../../shared/apps.dart';
+
 class SupportedFeaturesOverviewScreen extends StatefulWidget {
   const SupportedFeaturesOverviewScreen({super.key});
 
@@ -12,12 +14,12 @@ class SupportedFeaturesOverviewScreen extends StatefulWidget {
 
 final List<String> supportedApps = [
   // write in lower case only
-  "nachrichten",
-  "vertretungsplan",
-  "nachrichten - beta-version",
-  "mein unterricht",
-  "kalender",
-  "logout",
+  SPHAppEnum.nachrichten.str,
+  SPHAppEnum.vertretungsplan.str,
+  SPHAppEnum.nachrichtenBeta.str,
+  SPHAppEnum.meinUnterricht.str,
+  SPHAppEnum.kalender.str,
+  SPHAppEnum.logout.str,
 ];
 
 


### PR DESCRIPTION
Um Redundanz zu vermeiden und damit zukünftige Fehler, werden die Namen der Module zur Überprüfung ihrer Unterstützung in einem Enum aufgelistet. Dies führt vor allem dazu, dass die Liste unterstützter Module immer automatisch mit der tatsächlichen Unterstützung übereinstimmt, selbst wenn nur der Name geändert wird.