### PR TITLE
Modify substitutions widget to enable overflow title

### DIFF
--- a/app/lib/shared/marquee.dart
+++ b/app/lib/shared/marquee.dart
@@ -40,7 +40,9 @@ class _MarqueeWidgetState extends State<MarqueeWidget> {
       physics: const NeverScrollableScrollPhysics(),
       scrollDirection: widget.direction,
       controller: scrollController,
-      child: widget.child,
+      child: Center(
+        child: widget.child,
+      ),
     );
   }
 

--- a/app/lib/shared/marquee.dart
+++ b/app/lib/shared/marquee.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+class MarqueeWidget extends StatefulWidget {
+  final Widget child;
+  final Axis direction;
+  final Duration animationDuration, backDuration, pauseDuration;
+
+  const MarqueeWidget({
+    super.key,
+    required this.child,
+    this.direction = Axis.horizontal,
+    this.animationDuration = const Duration(milliseconds: 6000),
+    this.backDuration = const Duration(milliseconds: 800),
+    this.pauseDuration = const Duration(milliseconds: 800),
+  });
+
+  @override
+  _MarqueeWidgetState createState() => _MarqueeWidgetState();
+}
+
+class _MarqueeWidgetState extends State<MarqueeWidget> {
+  late ScrollController scrollController;
+
+  @override
+  void initState() {
+    scrollController = ScrollController(initialScrollOffset: 50.0);
+    WidgetsBinding.instance.addPostFrameCallback(scroll);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      physics: const NeverScrollableScrollPhysics(),
+      scrollDirection: widget.direction,
+      controller: scrollController,
+      child: widget.child,
+    );
+  }
+
+  void scroll(_) async {
+    while (scrollController.hasClients) {
+      await Future.delayed(widget.pauseDuration);
+      if (scrollController.hasClients) {
+        await scrollController.animateTo(
+          scrollController.position.maxScrollExtent,
+          duration: widget.animationDuration,
+          curve: Curves.ease,
+        );
+      }
+      await Future.delayed(widget.pauseDuration);
+      if (scrollController.hasClients) {
+        await scrollController.animateTo(
+          0.0,
+          duration: widget.backDuration,
+          curve: Curves.easeOut,
+        );
+      }
+    }
+  }
+}

--- a/app/lib/view/vertretungsplan/substitutionWidget.dart
+++ b/app/lib/view/vertretungsplan/substitutionWidget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 import '../../shared/marquee.dart';
 
@@ -44,7 +43,6 @@ class SubstitutionWidget extends StatelessWidget {
       dense: (doesNoticeExist(substitutionData["Vertreter"]) &&
           doesNoticeExist(substitutionData["Lehrer"]) &&
           doesNoticeExist(substitutionData["Raum"]) &&
-          doesNoticeExist(substitutionData["Fach"]) &&
           doesNoticeExist(substitutionData["Hinweis"])),
       title: Padding(
         padding: const EdgeInsets.only(top: 2),
@@ -60,82 +58,82 @@ class SubstitutionWidget extends StatelessWidget {
       subtitle: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Column(
-            children: [
-              Padding(
-                padding: EdgeInsets.only(
-                    top: 0,
-                    bottom: (doesNoticeExist(substitutionData["Vertreter"]) &&
-                        doesNoticeExist(substitutionData["Lehrer"]) &&
-                        doesNoticeExist(substitutionData["Raum"]) &&
-                        !doesNoticeExist(substitutionData["Fach"]))
-                        ? 12
-                        : 0),
-                child: Column(
-                  children: [
-                    getSubstitutionInfo(context,"Vertreter", substitutionData["Vertreter"],
-                        Icons.person) ??
-                        const SizedBox.shrink(),
-                    getSubstitutionInfo(context,
-                        "Lehrer", substitutionData["Lehrer"], Icons.school) ??
-                        const SizedBox.shrink(),
-                    getSubstitutionInfo(context,
-                        "Raum", substitutionData["Raum"], Icons.room) ??
-                        const SizedBox.shrink(),
-                  ],
-                ),
-              ),
-              if (!doesNoticeExist(substitutionData["Hinweis"])) ...[
-                Padding(
-                  padding: EdgeInsets.only(
-                      right: 30,
-                      left: 30,
-                      top: 2,
-                      bottom: doesNoticeExist(substitutionData["Fach"]) ? 12 : 0),
-                  child: Column(
+          Padding(
+            padding: EdgeInsets.only(
+                top: 0,
+                bottom: (doesNoticeExist(substitutionData["Vertreter"]) &&
+                    doesNoticeExist(substitutionData["Lehrer"]) &&
+                    doesNoticeExist(substitutionData["Raum"]) &&
+                    !doesNoticeExist(substitutionData["Fach"]))
+                    ? 12
+                    : 0),
+            child: Column(
+              children: [
+                getSubstitutionInfo(context,"Vertreter", substitutionData["Vertreter"],
+                    Icons.person) ??
+                    const SizedBox.shrink(),
+                getSubstitutionInfo(context,
+                    "Lehrer", substitutionData["Lehrer"], Icons.school) ??
+                    const SizedBox.shrink(),
+                getSubstitutionInfo(context,
+                    "Raum", substitutionData["Raum"], Icons.room) ??
+                    const SizedBox.shrink(),
+              ],
+            ),
+          ),
+          if (!doesNoticeExist(substitutionData["Hinweis"])) ...[
+            Padding(
+              padding: EdgeInsets.only(
+                  right: 30,
+                  left: 30,
+                  top: 2,
+                  bottom: doesNoticeExist(substitutionData["Fach"]) ? 12 : 0),
+              child: Column(
+                children: [
+                  Row(
                     children: [
-                      Row(
-                        children: [
-                          const Padding(
-                            padding: EdgeInsets.only(right: 8.0),
-                            child: Icon(Icons.info),
-                          ),
-                          Flexible(
-                            fit: FlexFit.loose,
-                            child: Text(
-                              substitutionData["Hinweis"],
-                              overflow: TextOverflow.visible,
-                              softWrap: true,
-                            ),
-                          ),
-                        ],
+                      const Padding(
+                        padding: EdgeInsets.only(right: 8.0),
+                        child: Icon(Icons.info),
                       ),
-                      const SizedBox(height: 4)
+                      Flexible(
+                        fit: FlexFit.loose,
+                        child: Text(
+                          substitutionData["Hinweis"],
+                          overflow: TextOverflow.visible,
+                          softWrap: true,
+                        ),
+                      ),
                     ],
                   ),
-                )
-              ]
-            ],
-          ),
-          if (!doesNoticeExist(substitutionData["Fach"])) ...[
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
+                  const SizedBox(height: 4)
+                ],
+              ),
+            )
+          ],
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              if (!doesNoticeExist(substitutionData["Fach"])) ...[
                 Text(
-                  substitutionData["Fach"] ?? "",
-                  style: Theme.of(context).textTheme.titleLarge,
-                ),
-                Text(
-                  substitutionData["Klasse"] ?? "Keine Klasse angegeben",
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                Text(
-                  substitutionData['Stunde'] ?? "",
+                  substitutionData["Fach"],
                   style: Theme.of(context).textTheme.titleLarge,
                 ),
               ],
-            )
-          ]
+              if (!doesNoticeExist(substitutionData["Klasse"])) ...[
+                Text(
+                  substitutionData["Klasse"],
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ],
+              if (!doesNoticeExist(substitutionData['Stunde'])) ...[
+                Text(
+                  substitutionData['Stunde'],
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+              ]
+            ],
+          ),
         ],
       ),
     );

--- a/app/lib/view/vertretungsplan/substitutionWidget.dart
+++ b/app/lib/view/vertretungsplan/substitutionWidget.dart
@@ -1,13 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import '../../shared/marquee.dart';
+
 class SubstitutionWidget extends StatelessWidget {
   final Map<String, dynamic> substitutionData;
   const SubstitutionWidget({super.key, required this.substitutionData});
-
-  // TODO VP REWORK ("revert")
-  // REWORK THIS SHIT SO IT DOESN'T USE CONFUSING IF STATEMENTS
-  // ALSO PUT HINWEIS IN THE SAME LINE AGAIN
 
   bool doesNoticeExist(String? info) {
     return (info == null || info == "" || info == "---");
@@ -35,7 +33,9 @@ class SubstitutionWidget extends StatelessWidget {
             ],
           ),
           Text(value!)
-        ]));
+        ]
+      )
+    );
   }
 
   @override
@@ -48,30 +48,14 @@ class SubstitutionWidget extends StatelessWidget {
           doesNoticeExist(substitutionData["Hinweis"])),
       title: Padding(
         padding: const EdgeInsets.only(top: 2),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            if (substitutionData['Art'] != null) ...[
-              Text(
-                substitutionData['Art'],
-                style: Theme.of(context).textTheme.titleLarge,
-              )
-            ],
-            Flexible(
-                child: Text(substitutionData["Klasse"] ?? "Keine Klasse angegeben",
-                    style: (substitutionData['Art'] != null)
-                        ? null
-                        : Theme.of(context)
-                        .textTheme
-                        .titleLarge) // highlight "Klasse" when there is no "Art" information
-            ),
-            Text(
-              substitutionData['Stunde'] ?? "",
-              style: Theme.of(context).textTheme.titleLarge,
-            ),
-          ],
-        ),
+        child: (substitutionData['Art'] != null) ?
+        MarqueeWidget(
+          direction: Axis.horizontal,
+          child: Text(
+            substitutionData['Art'],
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+        ) : null,
       ),
       subtitle: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -116,14 +100,17 @@ class SubstitutionWidget extends StatelessWidget {
                             padding: EdgeInsets.only(right: 8.0),
                             child: Icon(Icons.info),
                           ),
-                          Text(
-                            "Hinweis",
-                            style: Theme.of(context).textTheme.labelLarge,
-                          )
+                          Flexible(
+                            fit: FlexFit.loose,
+                            child: Text(
+                              substitutionData["Hinweis"],
+                              overflow: TextOverflow.visible,
+                              softWrap: true,
+                            ),
+                          ),
                         ],
                       ),
-                      Text(
-                          "${toBeginningOfSentenceCase(substitutionData["Hinweis"])}")
+                      const SizedBox(height: 4)
                     ],
                   ),
                 )
@@ -132,11 +119,19 @@ class SubstitutionWidget extends StatelessWidget {
           ),
           if (!doesNoticeExist(substitutionData["Fach"])) ...[
             Row(
-              mainAxisAlignment: MainAxisAlignment.end,
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text(
-                  substitutionData["Fach"],
-                  style: const TextStyle(fontSize: 18),
+                  substitutionData["Fach"] ?? "",
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                Text(
+                  substitutionData["Klasse"] ?? "Keine Klasse angegeben",
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                Text(
+                  substitutionData['Stunde'] ?? "",
+                  style: Theme.of(context).textTheme.titleLarge,
                 ),
               ],
             )

--- a/app/lib/view/vertretungsplan/substitutionWidget.dart
+++ b/app/lib/view/vertretungsplan/substitutionWidget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 import '../../shared/marquee.dart';
 
@@ -43,6 +44,7 @@ class SubstitutionWidget extends StatelessWidget {
       dense: (doesNoticeExist(substitutionData["Vertreter"]) &&
           doesNoticeExist(substitutionData["Lehrer"]) &&
           doesNoticeExist(substitutionData["Raum"]) &&
+          doesNoticeExist(substitutionData["Fach"]) &&
           doesNoticeExist(substitutionData["Hinweis"])),
       title: Padding(
         padding: const EdgeInsets.only(top: 2),
@@ -114,16 +116,21 @@ class SubstitutionWidget extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
+              if (!doesNoticeExist(substitutionData["Klasse"])) ...[
+                SizedBox(
+                  width: MediaQuery.of(context).size.width * 0.30,
+                  child: MarqueeWidget(
+                    child: Text(
+                      substitutionData["Klasse"],
+                      style: Theme.of(context).textTheme.titleMedium,
+                    )
+                  ),
+                ),
+              ],
               if (!doesNoticeExist(substitutionData["Fach"])) ...[
                 Text(
                   substitutionData["Fach"],
                   style: Theme.of(context).textTheme.titleLarge,
-                ),
-              ],
-              if (!doesNoticeExist(substitutionData["Klasse"])) ...[
-                Text(
-                  substitutionData["Klasse"],
-                  style: Theme.of(context).textTheme.titleMedium,
                 ),
               ],
               if (!doesNoticeExist(substitutionData['Stunde'])) ...[


### PR DESCRIPTION
Hier wird das Substitutionswidget so angepasst, dass es mit längeren Titeln wie in #136 zurechtkommt. Dazu werden Scroller verwendet. 
Jetzt sind auch die Hinweise in der gleichen Zeile wie das Icon.

Bei der Einführung der Laufschrift wurde eine schöne Animation erstellt, die ich beibehalten würde:

https://github.com/alessioC42/lanis-mobile/assets/84250128/075ea33a-ed86-4424-8447-1e502ec86b7f

closes #136