### PR TITLE
Reguläre Ausdrücke optimieren

### DIFF
--- a/app/lib/client/client.dart
+++ b/app/lib/client/client.dart
@@ -1094,7 +1094,7 @@ class SPHclient {
     var bytes = utf8.encode(source);
     var digest = sha256.convert(bytes);
 
-    var shortHash = digest.toString().replaceAll(RegExp(r'[^a-zA-Z0-9]'), '').substring(0, 6);
+    var shortHash = digest.toString().replaceAll(RegExp(r'[^A-z0-9]'), '').substring(0, 6);
 
     return shortHash;
   }

--- a/app/lib/client/cryptor.dart
+++ b/app/lib/client/cryptor.dart
@@ -167,7 +167,7 @@ class Cryptor {
 
   String decryptEncodedTags(String htmlString) {
     // Definiere das Muster für das <encoded> Tag
-    RegExp exp = RegExp(r'<encoded>(.*?)<\/encoded>');
+    RegExp exp = RegExp(r'(?<=<encoded>).*(?=</encoded>)');
 
     // Verwende die replaceAll-Funktion, um alle Übereinstimmungen zu ersetzen
     String replacedHtml = htmlString.replaceAllMapped(exp, (match) {

--- a/app/lib/client/cryptor.dart
+++ b/app/lib/client/cryptor.dart
@@ -167,7 +167,7 @@ class Cryptor {
 
   String decryptEncodedTags(String htmlString) {
     // Definiere das Muster für das <encoded> Tag
-    RegExp exp = RegExp(r'(?<=<encoded>).*(?=</encoded>)');
+    RegExp exp = RegExp(r'<encoded>(.*?)<\/encoded>');
 
     // Verwende die replaceAll-Funktion, um alle Übereinstimmungen zu ersetzen
     String replacedHtml = htmlString.replaceAllMapped(exp, (match) {

--- a/app/lib/client/cryptor.dart
+++ b/app/lib/client/cryptor.dart
@@ -172,7 +172,7 @@ class Cryptor {
     // Verwende die replaceAll-Funktion, um alle Übereinstimmungen zu ersetzen
     String replacedHtml = htmlString.replaceAllMapped(exp, (match) {
       // Extrahiere den Inhalt zwischen <encoded> und </encoded>
-      String? encodedContent = match.group(1);
+      String? encodedContent = match.group(0);
 
       // Entschlüssle den Inhalt und ersetze das Tag
       String? decryptedContent = decryptString(encodedContent!);

--- a/app/lib/client/cryptor.dart
+++ b/app/lib/client/cryptor.dart
@@ -172,7 +172,7 @@ class Cryptor {
     // Verwende die replaceAll-Funktion, um alle Übereinstimmungen zu ersetzen
     String replacedHtml = htmlString.replaceAllMapped(exp, (match) {
       // Extrahiere den Inhalt zwischen <encoded> und </encoded>
-      String? encodedContent = match.group(0);
+      String? encodedContent = match.group(1);
 
       // Entschlüssle den Inhalt und ersetze das Tag
       String? decryptedContent = decryptString(encodedContent!);

--- a/app/lib/view/calendar/calendar.dart
+++ b/app/lib/view/calendar/calendar.dart
@@ -119,7 +119,7 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
 
       data.forEach((key, value) {
         if (key == "-sus") {
-          targetGroup += "${value.replaceAll(RegExp(r"amp;"), "")}";
+          targetGroup += value.replaceAll("amp;", "").toString();
           return;
         }
         targetGroup += "$value, ";
@@ -267,7 +267,7 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
                       debugPrint("${link.url} konnte nicht geöffnet werden.");
                     }
                   },
-                  text: calendarData.data["description"].replaceAll(RegExp(r"<br />"), ""),
+                  text: calendarData.data["description"].replaceAll("<br />", "\n"),
                   style: Theme.of(context).textTheme.bodyLarge,
                   linkStyle: Theme.of(context)
                       .textTheme

--- a/app/lib/view/login/auth.dart
+++ b/app/lib/view/login/auth.dart
@@ -242,8 +242,8 @@ class LoginFormState extends State<LoginForm> {
 
 
 String extractNumber(str){
-  RegExp numberPattern = RegExp(r'\((\d+)\)');
+  RegExp numberPattern = RegExp(r'(?<=\()\d+(?=\))');
 
   Match match = numberPattern.firstMatch(str) as Match;
-  return match.group(1)!;
+  return match.group(0)!;
 }

--- a/app/lib/view/login/screen.dart
+++ b/app/lib/view/login/screen.dart
@@ -75,10 +75,3 @@ class _WelcomeLoginScreenState extends State<WelcomeLoginScreen> {
   }
 }
 
-String extractNumber(str){
-  RegExp numberPattern = RegExp(r'\((\d+)\)');
-
-  Match match = numberPattern.firstMatch(str) as Match;
-  return match.group(1)!;
-}
-


### PR DESCRIPTION
Einige reguläre Ausdrücke sind nicht optimal formuliert oder es wird RegExp verwendet, an Stellen, an denen es nicht notwendig ist.