### PR TITLE
Vertretungsplan Filter nach Semikolon-Liste

### DIFF
--- a/app/lib/view/vertretungsplan/filterlogic.dart
+++ b/app/lib/view/vertretungsplan/filterlogic.dart
@@ -2,23 +2,34 @@ import 'package:intl/intl.dart';
 
 import '../../client/storage.dart';
 
+final regMatchAll = RegExp(r'.*');
+final regMatchSimple = RegExp(r'\s*(?:[\d\w]\s*(?:;\s*|$))*');
+final regGroupSimple = RegExp(r'(?<=;|^)[\d\w\s]+(?=;|$)');
+
+String buildFilterRegex(String simpleList) {
+  return regGroupSimple.allMatches(simpleList).map((element) => element.group(0)!.trim()).join("|");
+}
+
 Future<List> filter(list) async {
 
   final String? klassenStufeStorage = await globalStorage.read(key: "filter-klassenStufe");
   late Pattern klassenStufe;
 
   if (klassenStufeStorage == null || klassenStufeStorage == "") {
-    klassenStufe = RegExp(r'.*');
+    klassenStufe = regMatchAll;
+  } else if (regMatchSimple.hasMatch(klassenStufeStorage)) {
+    klassenStufe = RegExp(buildFilterRegex(klassenStufeStorage));
   } else {
-    klassenStufe =
-        RegExp(klassenStufeStorage);
+    klassenStufe = RegExp(klassenStufeStorage);
   }
 
   final String? klasseStorage = await globalStorage.read(key: "filter-klasse");
   late Pattern klasse;
 
   if (klasseStorage == null || klasseStorage == "") {
-    klasse = RegExp(r'.*');
+    klasse = regMatchAll;
+  } else if (regMatchSimple.hasMatch(klasseStorage)) {
+    klasse = RegExp(buildFilterRegex(klasseStorage));
   } else {
     klasse = RegExp(klasseStorage);
   }
@@ -27,7 +38,9 @@ Future<List> filter(list) async {
   late Pattern lehrerKuerzel;
 
   if (lehrerKuerzelStorage == null || lehrerKuerzelStorage == "") {
-    lehrerKuerzel = RegExp(r'.*');
+    lehrerKuerzel = regMatchAll;
+  } else if (regMatchSimple.hasMatch(lehrerKuerzelStorage)) {
+    lehrerKuerzel = RegExp(buildFilterRegex(lehrerKuerzelStorage));
   } else {
     lehrerKuerzel = RegExp(lehrerKuerzelStorage);
   }

--- a/app/lib/view/vertretungsplan/filtersettings.dart
+++ b/app/lib/view/vertretungsplan/filtersettings.dart
@@ -106,10 +106,12 @@ class _FilterElementsState extends State<FilterElements> {
               decoration: const InputDecoration(
                   labelText: 'Lehrerkürzel (z.B. Abc; XYZ; Müller)')),
         ),
+        const ListTile(
+          leading: Icon(Icons.info_outline),
+          title: Text("Mehrere Filter"),
+          subtitle: Text("Du kannst mehrere Filter mit einem \";\" trennen. Beispiel: 7; 8; Q"),
+        )
       ],
     );
   }
 }
-
-
-


### PR DESCRIPTION
Bisher muss man Regex schreiben um die Filter zu benutzen.
Fügt die Möglichkeit hinzu auch mit durch Semikolons getrennte Listen zu filtern.