### PR TITLE
fix: exams not rendered due to change in Lanis Layout

### DIFF
--- a/app/lib/client/client_submodules/mein_unterricht.dart
+++ b/app/lib/client/client_submodules/mein_unterricht.dart
@@ -347,7 +347,11 @@ class MeinUnterrichtParser {
         var examSection = document.getElementById("klausuren");
         var lists = examSection?.children;
 
-        lists?.forEach((element) {
+        if (lists![0].text.contains("Diese Kursmappe beinhaltet leider noch keine Leistungskontrollen!")) {
+          return;
+        }
+
+        for (var element in lists) {
           String exams = "";
 
           final elements = element.querySelectorAll("ul li");
@@ -367,7 +371,7 @@ class MeinUnterrichtParser {
             "title": element.querySelector("h1,h2,h3,h4,h5,h6")?.text.trim(),
             "value": exams == "" ? "Keine Daten!" : exams
           });
-        });
+        }
       }();
 
       return result;

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none'
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.15.1+31
+version: 2.16.0+32
 
 environment:
   sdk: '>=3.1.3 <4.0.0'


### PR DESCRIPTION
Due to (what I think is) a change in the interface of "My Lessons" in the SPH web interface, the Exam section was not displayed correctly in the Application. I think I fixed it, but I cannot test it because none of my courses use the Exam section. @kurwjan, if I remember correctly you had something in there?