### PR TITLE
Added Per-App Language functionality (for Language Picker via Android Settings)

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:enableOnBackInvokedCallback="true"
+        android:localeConfig="@xml/locales_config">
+
     >
         <activity
             android:name=".MainActivity"

--- a/app/android/app/src/main/res/xml/locales_config.xml
+++ b/app/android/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="de"/>
+    <locale android:name="en-US"/>
+</locale-config>

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -3,6 +3,18 @@ allprojects {
         google()
         mavenCentral()
     }
+    subprojects {
+        afterEvaluate { project ->
+            if (project.hasProperty('android')) {
+                project.android {
+                    if (namespace == null) {
+                        namespace project.group
+                    }
+                }
+            }
+        }
+    }
+
 }
 
 rootProject.buildDir = '../build'

--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/app/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/app/android/settings.gradle
+++ b/app/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.1" apply false
+    id "com.android.application" version '8.1.4' apply false
     id "org.jetbrains.kotlin.android" version "1.9.24" apply false
 }
 

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -1,5 +1,6 @@
 {
   "locale": "de_DE",
+  "language": "Sprache",
   "welcomeBack": "Wilkommen zurück",
   "substitutions": "Vertretungen",
   "calendar": "Kalender",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1,5 +1,6 @@
 {
   "locale": "en_US",
+  "language": "Language",
   "welcomeBack": "Welcome Back",
   "substitutions": "Substitutions",
   "calendar": "Calendar",

--- a/app/lib/view/settings/settings.dart
+++ b/app/lib/view/settings/settings.dart
@@ -1,3 +1,9 @@
+import 'dart:io';
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/material.dart';
+import 'package:app_settings/app_settings.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:sph_plan/view/settings/subsettings/about.dart';
 import 'package:sph_plan/view/settings/subsettings/clear_cache.dart';
 import 'package:sph_plan/view/settings/subsettings/countly_analysis.dart';
@@ -5,13 +11,11 @@ import 'package:sph_plan/view/settings/subsettings/notifications.dart';
 import 'package:sph_plan/view/settings/subsettings/supported_features.dart';
 import 'package:sph_plan/view/settings/subsettings/theme_changer.dart';
 import 'package:sph_plan/view/settings/subsettings/userdata.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../shared/apps.dart';
 import '../login/screen.dart';
 import '../../client/client.dart';
 
-import 'package:flutter/material.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -21,6 +25,26 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
+  bool isAndroid13OrHigher = false;
+
+  setLocaleAllowed() async {
+    DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
+    AndroidDeviceInfo androidInfo = await deviceInfo.androidInfo;
+    if (androidInfo.version.sdkInt >= 33) {
+      setState(() {
+        isAndroid13OrHigher = true;
+      });
+    }
+  }
+
+  @override
+  void initState() {
+    if (Platform.isAndroid) {
+      setLocaleAllowed();
+    }
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -108,6 +132,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 MaterialPageRoute(builder: (context) => const AboutScreen()),
               );
             },
+          ),
+          if (isAndroid13OrHigher) ListTile(
+            leading: const Icon(Icons.language),
+            title: Text(AppLocalizations.of(context)!.language),
+            onTap: () => AppSettings.openAppSettings(type: AppSettingsType.appLocale),
           ),
           ListTile(
             leading: const Icon(Icons.logout),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -67,6 +67,8 @@ dependencies:
   logger: ^2.2.0
   simple_shadow: ^0.3.1
   flutter_tagging_plus: ^4.0.2
+  app_settings: ^5.1.1
+  device_info_plus: ^10.1.0
 
 
 flutter_launcher_icons:


### PR DESCRIPTION
Android 13 Introduced [Per-app language preferences](https://developer.android.com/guide/topics/resources/app-languages)  that allow the user to pick a locale for a specific app regardless of system language. This would be a solution for a locale picker (at least on Android 13+) for older version there would be the need for a in app locale picker but this can be added later and a In-App and Android Settings locale picker should work at the same time according to Android Developers so #213 will not be closed.
Demo (ignore that the last one is only half visible that is a bug in OneUI that also happens to other Apps):

https://github.com/user-attachments/assets/9e4eb5f5-8d62-4ebb-91e0-51c3f4559074

