### PR TITLE
Removed .ipa section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,6 @@ Wir sind offen für neue Colaborator. Aber auch wenn du nicht coden kannst, bist
 
 Es werden anonyme Daten zur Fehleranalyse erhoben. (Optional)
 
-
-## IOS/IpadOS support
-Die App ist zwar noch nicht im App Store, es kann jedoch eine .IPA Datei unter "releases" heruntergeladen und installiert werden. Dabei finden keine automatischen Updates statt.
-
-iOS wurde bisher ausschließlich durch die Immanuel Kant Schule (5181) getestet.
-
 ## Mitarbeit
 [Schulkonfiguration der Vertretungspläne](https://github.com/alessioC42/lanis-mobile-autoconfig)
 


### PR DESCRIPTION
The App is in the App Store and was tested by more Schools than listed (including my own). So this section is no longer needed.