### PR TITLE
Replace http_proxy with a fork which supports v3.24.x

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   http_proxy:
     git:
       url: https://github.com/Rajala1404/http_proxy.git
-      ref: master
+      ref: 41d7f3d
   flutter:
     sdk: flutter
   dio_cookie_manager: ^3.1.0+1

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -20,7 +20,10 @@ environment:
   sdk: '>=3.1.3 <4.0.0'
 
 dependencies:
-  http_proxy: ^1.2.2
+  http_proxy:
+    git:
+      url: https://github.com/Rajala1404/http_proxy.git
+      ref: master
   flutter:
     sdk: flutter
   dio_cookie_manager: ^3.1.0+1


### PR DESCRIPTION
Fails in `release mode` to build and logs something like this: `"AAPT: error: resource android:attr/lStar not found."`

Related issue: https://github.com/flutter/flutter/issues/153281
Fork from @Rajala1404: https://github.com/Rajala1404/http_proxy